### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/scripts/gradlew_recursive.sh
+++ b/.github/scripts/gradlew_recursive.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+# Default Gradle settings are not optimal for Android builds, override them
+# here to make the most out of the GitHub Actions build servers
+GRADLE_OPTS="$GRADLE_OPTS -Xms4g -Xmx4g"
+GRADLE_OPTS="$GRADLE_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.daemon=false"
+GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.workers.max=2"
+GRADLE_OPTS="$GRADLE_OPTS -Dkotlin.incremental=false"
+GRADLE_OPTS="$GRADLE_OPTS -Dkotlin.compiler.execution.strategy=in-process"
+GRADLE_OPTS="$GRADLE_OPTS -Dfile.encoding=UTF-8"
+export GRADLE_OPTS
+
+# Crawl all gradlew files which indicate an Android project
+# You may edit this if your repo has a different project structure
+for GRADLEW in `find . -name "gradlew"` ; do
+    SAMPLE=$(dirname "${GRADLEW}")
+    # Tell Gradle that this is a CI environment and disable parallel compilation
+    bash "$GRADLEW" -p "$SAMPLE" -Pci --no-parallel --stacktrace $@
+done

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Android CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build project
+        run: .github/scripts/gradlew_recursive.sh assembleDebug
+      - name: Zip artifacts
+        run: zip -r assemble.zip . -i '**/build/*.apk' '**/build/*.aab' '**/build/*.aar' '**/build/*.so'
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: assemble
+          path: assemble.zip


### PR DESCRIPTION
This enables automatic builds for new commits and PRs in the master branch.
This sample is currently **green**, see build logs:

+ GRADLE_OPTS=' -Xms4g -Xmx4g'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dfile.encoding=UTF-8'
+ export GRADLE_OPTS
++ find . -name gradlew
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/uiautomator/BasicSample/gradlew
+ SAMPLE=./ui/uiautomator/BasicSample
+ bash ./ui/uiautomator/BasicSample/gradlew -p ./ui/uiautomator/BasicSample -Pci --no-parallel --stacktrace assembleDebug
Download https://jcenter.bintray.com/org/jetbrains/kotlin/kotlin-stdlib/1.2.20/kotlin-stdlib-1.2.20.pom
Download https://jcenter.bintray.com/org/jetbrains/kotlin/kotlin-stdlib/1.2.20/kotlin-stdlib-1.2.20.jar
:app:checkDebugClasspath
Download https://jcenter.bintray.com/com/google/guava/guava/26.0-android/guava-26.0-android.pom
Download https://jcenter.bintray.com/org/checkerframework/checker-compat-qual/2.5.2/checker-compat-qual-2.5.2.pom
Download https://jcenter.bintray.com/com/google/guava/guava/26.0-android/guava-26.0-android.jar
Download https://jcenter.bintray.com/org/checkerframework/checker-compat-qual/2.5.2/checker-compat-qual-2.5.2.jar
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 46s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/DataAdapterSample/gradlew
+ SAMPLE=./ui/espresso/DataAdapterSample
+ bash ./ui/espresso/DataAdapterSample/gradlew -p ./ui/espresso/DataAdapterSample -Pci --no-parallel --stacktrace assembleDebug
WARNING: The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported.
The current default is 'false'

:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 20s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/MultiWindowSample/gradlew
+ SAMPLE=./ui/espresso/MultiWindowSample
+ bash ./ui/espresso/MultiWindowSample/gradlew -p ./ui/espresso/MultiWindowSample -Pci --no-parallel --stacktrace assembleDebug
:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 13s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/FragmentScenarioSample/gradlew
+ SAMPLE=./ui/espresso/FragmentScenarioSample
+ bash ./ui/espresso/FragmentScenarioSample/gradlew -p ./ui/espresso/FragmentScenarioSample -Pci --no-parallel --stacktrace assembleDebug
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/5.1.1/userguide/gradle_daemon.html.
Daemon will be stopped at the end of the build stopping after processing
> Task :app:preBuild UP-TO-DATE
> Task :app:preDebugBuild
> Task :app:compileDebugAidl NO-SOURCE
> Task :app:compileDebugRenderscript NO-SOURCE
> Task :app:checkDebugManifest
> Task :app:generateDebugBuildConfig
> Task :app:mainApkListPersistenceDebug
> Task :app:generateDebugResValues
> Task :app:generateDebugResources
> Task :app:mergeDebugResources
> Task :app:createDebugCompatibleScreenManifests
> Task :app:processDebugManifest
> Task :app:processDebugResources
> Task :app:compileDebugKotlin
> Task :app:prepareLintJar
> Task :app:generateDebugSources
> Task :app:javaPreCompileDebug
> Task :app:compileDebugJavaWithJavac
> Task :app:compileDebugSources
> Task :app:mergeDebugShaders
> Task :app:compileDebugShaders
> Task :app:generateDebugAssets
> Task :app:mergeDebugAssets
> Task :app:checkDebugDuplicateClasses
> Task :app:transformClassesWithDexBuilderForDebug
> Task :app:validateSigningDebug
> Task :app:signingConfigWriterDebug
> Task :app:mergeDebugJniLibFolders
> Task :app:transformNativeLibsWithMergeJniLibsForDebug
> Task :app:transformNativeLibsWithStripDebugSymbolForDebug
> Task :app:processDebugJavaRes NO-SOURCE
> Task :app:transformResourcesWithMergeJavaResForDebug
> Task :app:mergeExtDexDebug
> Task :app:mergeDexDebug
> Task :app:packageDebug
> Task :app:assembleDebug

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 35s
27 actionable tasks: 27 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/IntentsBasicSample/gradlew
+ SAMPLE=./ui/espresso/IntentsBasicSample
+ bash ./ui/espresso/IntentsBasicSample/gradlew -p ./ui/espresso/IntentsBasicSample -Pci --no-parallel --stacktrace assembleDebug
WARNING: The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported.
The current default is 'false'

:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 17s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/WebBasicSample/gradlew
+ SAMPLE=./ui/espresso/WebBasicSample
+ bash ./ui/espresso/WebBasicSample/gradlew -p ./ui/espresso/WebBasicSample -Pci --no-parallel --stacktrace assembleDebug
:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
Note: /Users/owahltinez/Sandbox/samples/testing-samples/ui/espresso/WebBasicSample/app/src/main/java/com/example/android/testing/espresso/web/BasicSample/WebViewActivity.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 14s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/CustomMatcherSample/gradlew
+ SAMPLE=./ui/espresso/CustomMatcherSample
+ bash ./ui/espresso/CustomMatcherSample/gradlew -p ./ui/espresso/CustomMatcherSample -Pci --no-parallel --stacktrace assembleDebug
WARNING: The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported.
The current default is 'false'

:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 15s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/BasicSample/gradlew
+ SAMPLE=./ui/espresso/BasicSample
+ bash ./ui/espresso/BasicSample/gradlew -p ./ui/espresso/BasicSample -Pci --no-parallel --stacktrace assembleDebug
WARNING: The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported.
The current default is 'false'

:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:compileDebugKotlin
:app:prepareLintJar
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 25s
29 actionable tasks: 29 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/IdlingResourceSample/gradlew
+ SAMPLE=./ui/espresso/IdlingResourceSample
+ bash ./ui/espresso/IdlingResourceSample/gradlew -p ./ui/espresso/IdlingResourceSample -Pci --no-parallel --stacktrace assembleDebug
:app:checkDebugClasspath
Download https://dl.google.com/dl/android/maven2/androidx/test/espresso/espresso-idling-resource/3.3.0-alpha04/espresso-idling-resource-3.3.0-alpha04.pom
Download https://dl.google.com/dl/android/maven2/androidx/test/espresso/espresso-idling-resource/3.3.0-alpha04/espresso-idling-resource-3.3.0-alpha04.aar
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 19s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/AccessibilitySample/gradlew
+ SAMPLE=./ui/espresso/AccessibilitySample
+ bash ./ui/espresso/AccessibilitySample/gradlew -p ./ui/espresso/AccessibilitySample -Pci --no-parallel --stacktrace assembleDebug
> Task :app:preBuild UP-TO-DATE
> Task :app:preDebugBuild UP-TO-DATE
> Task :app:compileDebugAidl NO-SOURCE
> Task :app:compileDebugRenderscript NO-SOURCE
> Task :app:checkDebugManifest
> Task :app:generateDebugBuildConfig
> Task :app:mainApkListPersistenceDebug
> Task :app:generateDebugResValues
> Task :app:javaPreCompileDebug
> Task :app:generateDebugResources
> Task :app:createDebugCompatibleScreenManifests
> Task :app:processDebugManifest
> Task :app:mergeDebugShaders
> Task :app:compileDebugShaders
> Task :app:generateDebugAssets
> Task :app:mergeDebugAssets
> Task :app:processDebugJavaRes NO-SOURCE
> Task :app:checkDebugDuplicateClasses
> Task :app:mergeDebugResources
> Task :app:processDebugResources
> Task :app:compileDebugJavaWithJavac
> Task :app:mergeExtDexDebug
> Task :app:compileDebugSources
> Task :app:transformClassesWithDexBuilderForDebug
> Task :app:mergeDebugJavaResource
> Task :app:validateSigningDebug
> Task :app:signingConfigWriterDebug
> Task :app:mergeDebugJniLibFolders
> Task :app:mergeDebugNativeLibs
> Task :app:stripDebugDebugSymbols
> Task :app:mergeDexDebug
> Task :app:packageDebug
> Task :app:assembleDebug

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.4.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 42s
24 actionable tasks: 24 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/IntentsAdvancedSample/gradlew
+ SAMPLE=./ui/espresso/IntentsAdvancedSample
+ bash ./ui/espresso/IntentsAdvancedSample/gradlew -p ./ui/espresso/IntentsAdvancedSample -Pci --no-parallel --stacktrace assembleDebug
:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 11s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/RecyclerViewSample/gradlew
+ SAMPLE=./ui/espresso/RecyclerViewSample
+ bash ./ui/espresso/RecyclerViewSample/gradlew -p ./ui/espresso/RecyclerViewSample -Pci --no-parallel --stacktrace assembleDebug
WARNING: The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported.
The current default is 'false'

:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 19s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./ui/espresso/MultiProcessSample/gradlew
+ SAMPLE=./ui/espresso/MultiProcessSample
+ bash ./ui/espresso/MultiProcessSample/gradlew -p ./ui/espresso/MultiProcessSample -Pci --no-parallel --stacktrace assembleDebug
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/4.6/userguide/gradle_daemon.html.
Daemon will be stopped at the end of the build stopping after processing
:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 15s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./unit/BasicUnitAndroidTest/gradlew
+ SAMPLE=./unit/BasicUnitAndroidTest
+ bash ./unit/BasicUnitAndroidTest/gradlew -p ./unit/BasicUnitAndroidTest -Pci --no-parallel --stacktrace assembleDebug
:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 13s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./unit/BasicSample/gradlew
+ SAMPLE=./unit/BasicSample
+ bash ./unit/BasicSample/gradlew -p ./unit/BasicSample -Pci --no-parallel --stacktrace assembleDebug
WARNING: Configuration 'testCompile' is obsolete and has been replaced with 'testImplementation' and 'testApi'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
WARNING: Configuration 'testApi' is obsolete and has been replaced with 'testImplementation'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
:app:checkDebugClasspath
:app:preBuild UP-TO-DATE
:app:preDebugBuild
:app:compileDebugAidl NO-SOURCE
:app:compileDebugRenderscript
:app:checkDebugManifest
:app:generateDebugBuildConfig
:app:prepareLintJar
:app:mainApkListPersistenceDebug
:app:generateDebugResValues
:app:generateDebugResources
:app:mergeDebugResources
:app:createDebugCompatibleScreenManifests
:app:processDebugManifest
:app:splitsDiscoveryTaskDebug
:app:processDebugResources
:app:generateDebugSources
:app:javaPreCompileDebug
:app:compileDebugJavaWithJavac
:app:compileDebugNdk NO-SOURCE
:app:compileDebugSources
:app:mergeDebugShaders
:app:compileDebugShaders
:app:generateDebugAssets
:app:mergeDebugAssets
:app:transformClassesWithDexBuilderForDebug
:app:transformDexArchiveWithExternalLibsDexMergerForDebug
:app:transformDexArchiveWithDexMergerForDebug
:app:mergeDebugJniLibFolders
:app:transformNativeLibsWithMergeJniLibsForDebug
:app:transformNativeLibsWithStripDebugSymbolForDebug
:app:checkDebugLibraries
:app:processDebugJavaRes NO-SOURCE
:app:transformResourcesWithMergeJavaResForDebug
:app:validateSigningDebug
:app:packageDebug
:app:assembleDebug

BUILD SUCCESSFUL in 13s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./unit/BasicSample-kotlinApp/gradlew
+ SAMPLE=./unit/BasicSample-kotlinApp
+ bash ./unit/BasicSample-kotlinApp/gradlew -p ./unit/BasicSample-kotlinApp -Pci --no-parallel --stacktrace assembleDebug